### PR TITLE
Drobna poprawka w aj.lua

### DIFF
--- a/resources/[XyzzyRP]/lss-core/aj.lua
+++ b/resources/[XyzzyRP]/lss-core/aj.lua
@@ -78,7 +78,7 @@ function aj_process()
 	    exports.DB:zapytanie(query)
 	    if (aj<=0) then
 		outputChatBox("Twój AJ się skończył, możesz opuścić więzienie.", v, 255,0,0,true)
-		removeElementData(v,"kary_blokada_aj")
+		removeElementData(v,"kary:blokada_aj")
 	    end
 	end
 --	end


### PR DESCRIPTION
Gdy AJ się skończył, a gracz miał opuścić więzienie nie usuwano poprawnie daty 'kary:blokada_aj' (zamiast jej było wpisane 'kary_blokada_aj').