### PR TITLE
Usunięcie znaku powodującego error

### DIFF
--- a/resources/[XyzzyRP]/lss-gui/laser_c.lua
+++ b/resources/[XyzzyRP]/lss-gui/laser_c.lua
@@ -8,7 +8,7 @@
 
 
 
-﻿local lastChange = 0
+local lastChange = 0
 
 local laser = {}
 


### PR DESCRIPTION
Lasery nie włączały się z powodu znaku przed deklarowaniem zmiennej (niewidoczny na gicie, w Notepadzie++ jako ï»¿).