### PR TITLE
Wczytywanie pliku .lua zamiast .luac

### DIFF
--- a/resources/[XyzzyRP]/lss-gui/meta.xml
+++ b/resources/[XyzzyRP]/lss-gui/meta.xml
@@ -1,76 +1,76 @@
 <meta>
-<!--    <min_mta_version client="1.3.0-9.03772" server="1.3.0-9.03772" />-->
-    <min_mta_version client="1.3.0-9.04710" server="1.3.0-9.03772" />
-    
-    <file src="audio/karol-intro1.ogg" type="client" />
-    <file src="audio/karol-intro2on.ogg" type="client" />
-    <file src="audio/karol-intro3.ogg" type="client" />
-    <file src="audio/karol-intro4.ogg" type="client" />
-    <file src="audio/karol-noniezledostaleswdupe.ogg" type="client" />
-    
-    <file src="audio/dzwon.ogg" type="client" />
-    <file src="audio/dzwon2.ogg" type="client" />
-    <file src="audio/dzwon-single.mp3" type="client" />
-<!--<file src="audio/marchios-los_santos_stories.ogg" type="client" />-->
-<!--<file src="audio/marchios-los_santos.ogg" type="client" />-->
-<!--<file src="audio/marchios-ls2.ogg" type="client" />-->
-<!--<file src="audio/kubat-los_santos_stories.ogg" type="client" />-->
-	<!--<file src="audio/radioactive.ogg" type="client" />-->
-<!--<file src="audio/marchios-ls3.ogg" type="client" />-->
-<!--	<file src="audio/marchios-christmas.ogg" type="client" />-->
-	<file src="audio/loni2.ogg" type="client" />
-    
-    <file src="audio/ambiance-crowd.ogg" type="client" />
-   	<file src="audio/heartbeat.mp3" type="client" />
-	
-	<file src="audio/nokiatune.ogg" type="client" />
-	
-    <file src="img/lss.png" type="client" />
-    <file src="img/arrow.png" type="client" />
-    <file src="img/keys.png" type="client" />
-    <file src="img/pda.png" type="client" />
-    <file src="img/nav.png" type="client" />
+	<!--<min_mta_version client="1.3.0-9.03772" server="1.3.0-9.03772" />-->
+	<min_mta_version client="1.3.0-9.04710" server="1.3.0-9.03772" />
 
-    <file src="img/telefon.png" type="client" />
+	<file src="audio/karol-intro1.ogg" type="client" />
+	<file src="audio/karol-intro2on.ogg" type="client" />
+	<file src="audio/karol-intro3.ogg" type="client" />
+	<file src="audio/karol-intro4.ogg" type="client" />
+	<file src="audio/karol-noniezledostaleswdupe.ogg" type="client" />
+
+	<file src="audio/dzwon.ogg" type="client" />
+	<file src="audio/dzwon2.ogg" type="client" />
+	<file src="audio/dzwon-single.mp3" type="client" />
+	<!--<file src="audio/marchios-los_santos_stories.ogg" type="client" />-->
+	<!--<file src="audio/marchios-los_santos.ogg" type="client" />-->
+	<!--<file src="audio/marchios-ls2.ogg" type="client" />-->
+	<!--<file src="audio/kubat-los_santos_stories.ogg" type="client" />-->
+	<!--<file src="audio/radioactive.ogg" type="client" />-->
+	<!--<file src="audio/marchios-ls3.ogg" type="client" />-->
+	<!--<file src="audio/marchios-christmas.ogg" type="client" />-->
+	<file src="audio/loni2.ogg" type="client" />
+
+	<file src="audio/ambiance-crowd.ogg" type="client" />
+	<file src="audio/heartbeat.mp3" type="client" />
+
+	<file src="audio/nokiatune.ogg" type="client" />
+
+	<file src="img/lss.png" type="client" />
+	<file src="img/arrow.png" type="client" />
+	<file src="img/keys.png" type="client" />
+	<file src="img/pda.png" type="client" />
+	<file src="img/nav.png" type="client" />
+
+	<file src="img/telefon.png" type="client" />
 
 	<file src="droid-sans.ttf" type="client" />
-    <file src="img/EQ_aparat_fotograficzny.png" type="client" />	
-    <file src="img/EQ_blank.png" type="client" />
-    <file src="img/EQ_zeton.png" type="client" />
-    <file src="img/EQ_papierosy.png" type="client" />
-    <file src="img/EQ_aparat.png" type="client" />
-    <file src="img/EQ_mapa.png" type="client" />    
+	<file src="img/EQ_aparat_fotograficzny.png" type="client" />	
+	<file src="img/EQ_blank.png" type="client" />
+	<file src="img/EQ_zeton.png" type="client" />
+	<file src="img/EQ_papierosy.png" type="client" />
+	<file src="img/EQ_aparat.png" type="client" />
+	<file src="img/EQ_mapa.png" type="client" />    
 	<file src="img/EQ_obroza.png" type="client" />    
-    <file src="img/EQ_mapa_duza.jpg" type="client" />
-    <file src="img/EQ_aspiryna.png" type="client" />
-    <file src="img/EQ_kluczyki_auto.png" type="client" />
-    <file src="img/EQ_kluczyki_kurierzy.png" type="client" />	
-    <file src="img/EQ_kluczyki_policja.png" type="client" />
+	<file src="img/EQ_mapa_duza.jpg" type="client" />
+	<file src="img/EQ_aspiryna.png" type="client" />
+	<file src="img/EQ_kluczyki_auto.png" type="client" />
+	<file src="img/EQ_kluczyki_kurierzy.png" type="client" />	
+	<file src="img/EQ_kluczyki_policja.png" type="client" />
 	<file src="img/EQ_grill.png" type="client" />
-    <file src="img/EQ_kluczyki_sm.png" type="client" />    
-    <file src="img/EQ_kluczyki_warsztat.png" type="client" />
+	<file src="img/EQ_kluczyki_sm.png" type="client" />    
+	<file src="img/EQ_kluczyki_warsztat.png" type="client" />
 	<file src="img/EQ_prezent.png" type="client" />
-    <file src="img/EQ_kluczyki_ochrony.png" type="client" />
-    <file src="img/EQ_kluczyki_cnn_news.png" type="client" />	
-    <file src="img/EQ_kluczyki_urzad_miasta.png" type="client" />
-    <file src="img/EQ_kluczyki_import.png" type="client" />
-    <file src="img/EQ_kluczyki_gornikow.png" type="client" />
-    <file src="img/EQ_kluczyki_sadu_rejonowego.png" type="client" />
-    <file src="img/EQ_kluczyki_sluzb_wieziennych.png" type="client" />
-    <file src="img/EQ_kluczyki_sluzb_specjalnych.png" type="client" />    	
-    <file src="img/EQ_kluczyki_przychodni_lekarskiej.png" type="client" />    		
-    <file src="img/EQ_pda.png" type="client" />
-    <file src="img/EQ_ryba.png" type="client" />
-    <file src="img/EQ_ryba_1.png" type="client" />
+	<file src="img/EQ_kluczyki_ochrony.png" type="client" />
+	<file src="img/EQ_kluczyki_cnn_news.png" type="client" />	
+	<file src="img/EQ_kluczyki_urzad_miasta.png" type="client" />
+	<file src="img/EQ_kluczyki_import.png" type="client" />
+	<file src="img/EQ_kluczyki_gornikow.png" type="client" />
+	<file src="img/EQ_kluczyki_sadu_rejonowego.png" type="client" />
+	<file src="img/EQ_kluczyki_sluzb_wieziennych.png" type="client" />
+	<file src="img/EQ_kluczyki_sluzb_specjalnych.png" type="client" />    	
+	<file src="img/EQ_kluczyki_przychodni_lekarskiej.png" type="client" />    		
+	<file src="img/EQ_pda.png" type="client" />
+	<file src="img/EQ_ryba.png" type="client" />
+	<file src="img/EQ_ryba_1.png" type="client" />
 	<file src="img/EQ_karma.png" type="client" />
 	<file src="img/EQ_kielbasa1.png" type="client" />
 	<file src="img/EQ_kielbasa2.png" type="client" />
 	<file src="img/EQ_boombox.png" type="client" />
-    <file src="img/EQ_smieci.png" type="client" />
-    <file src="img/EQ_kwit.png" type="client" />
+	<file src="img/EQ_smieci.png" type="client" />
+	<file src="img/EQ_kwit.png" type="client" />
 	<file src="img/EQ_laser.png" type="client" />
-    <file src="img/EQ_paczka.png" type="client" />
-    <file src="img/EQ_nav.png" type="client" />
+	<file src="img/EQ_paczka.png" type="client" />
+	<file src="img/EQ_nav.png" type="client" />
 	<file src="img/EQ_prawojazdy.png" type="client" />
 	<file src="img/EQ_snajperka.png" type="client" />
 	<file src="img/EQ_pill1.png" type="client" />
@@ -193,10 +193,10 @@
 	<file src="img/EQ_oipum.png" type="client" />
 	<file src="img/EQ_heronina.png" type="client" />
 	<file src="img/EQ_extas.png" type="client" />
-	
+
 	<file src="img/EQ_granathukowy.png" type="client" />
 	<file src="img/EQ_granatdymny.png" type="client" />
-	
+
 	<file src="img/engine.png" type="client" />
 	<file src="img/locked.png" type="client" />
 	<file src="img/licznik.png" type="client" />
@@ -213,67 +213,67 @@
 	<file src="img/cn6.png" type="client" />
 	<file src="img/cn7.png" type="client" />
 
-    <file src="img/bgcolor.png" type="client" />
+	<file src="img/bgcolor.png" type="client" />
 
-    <file src="fx/grayscale.fx" type="client" />
-    <file src="fx/motion.fx" type="client" />
-    
-    <script src="utils.lua" type="client" />
+	<file src="fx/grayscale.fx" type="client" />
+	<file src="fx/motion.fx" type="client" />
+
+	<script src="utils.lua" type="client" cache="false" />
 
 	<script src="items.lua" type="server" />
 
 
 	<script src="weapons.lua" type="server" />
-	<script src="weapons_c.lua" type="client" />
-	<script src="paliwo_c.lua" type="client" />
-	
-	<script src="laser_c.lua" type="client" />
-	
-	<script src="drugs_c.lua" type="client" />
-	<script src="drugs.lua" type="server" />
-	
-    <script src="gui_c_.luac" type="client" />
-    <script src="nametags_c.lua" type="client" />
-    <script src="intro.lua" type="client" />
-    <script src="dzwony.lua" type="client" />
-    <script src="vehicles.lua" type="server" />
-    <script src="vehicles_c.lua" type="client" />
+	<script src="weapons_c.lua" type="client" cache="false" />
+	<script src="paliwo_c.lua" type="client" cache="false" />
 
-    <script src="test_ani.lua" type="client" />
-	<script src="gazeta_c.lua" type="client" />
-    <script src="ekwipunek.luac" type="client" />
+	<script src="laser_c.lua" type="client" cache="false" />
+
+	<script src="drugs_c.lua" type="client" cache="false" />
+	<script src="drugs.lua" type="server" />
+
+	<script src="gui_c_.lua" type="client" cache="false" />
+	<script src="nametags_c.lua" type="client" cache="false" />
+	<script src="intro.lua" type="client" cache="false" />
+	<script src="dzwony.lua" type="client" cache="false" />
+	<script src="vehicles.lua" type="server" />
+	<script src="vehicles_c.lua" type="client" cache="false" />
+
+	<script src="test_ani.lua" type="client" cache="false" />
+	<script src="gazeta_c.lua" type="client" cache="false" />
+	<script src="ekwipunek.lua" type="client" cache="false" />
 	<script src="ekwipunek_s.lua" type="server" />
 
 	<script src="telefon.lua" type="server" />
-    <script src="telefon_c_.luac" type="client" />
+	<script src="telefon_c_.lua" type="client" cache="false" />
 
 
-    <script src="mapa.lua" type="client" />
-    
-	<script src="death_c.lua" type="client" />
-  	<script src="death.lua" type="server" />
-	
-    <script src="soundplaces.lua" type="client" />
+	<script src="mapa.lua" type="client" cache="false" />
+
+	<script src="death_c.lua" type="client" cache="false" />
+	<script src="death.lua" type="server" />
+
+	<script src="soundplaces.lua" type="client" cache="false" />
 	<script src="papierosy.lua" type="server" />
 	<script src="kamizelki.lua" type="server" />
 	<script src="iphone_s.lua" type="server" />
 	<script src="torby.lua" type="server" />
-	<script src="afk_c.luac" type="client" />
-	<script src="carblips_c.lua" type="client" />
-    
-    <script src="frakcje_c.lua" type="client" />
-    <script src="pback.lua" type="server" />
-    
-    <export function="panel_hide" type="client" />	<!-- lss-autobusy -->
-    <export function="panel_show" type="client" />	<!-- uzywane przez lss-kasyno -->
-	
+	<script src="afk_c.lua" type="client" cache="false" />
+	<script src="carblips_c.lua" type="client" cache="false" />
 
-    <export function="eq_getItemByID" type="client" />
-    <export function="eq_takeItem" type="client" />
-    <export function="eq_giveItem" type="client" />
-    <export function="eq_get" type="client" />
-    <export function="eq_item_nav_turnOff" type="client" />
-    <export function="eq_item_nav_clear" type="client" />
+	<script src="frakcje_c.lua" type="client" cache="false" />
+	<script src="pback.lua" type="server" />
+
+	<export function="panel_hide" type="client" />	<!-- lss-autobusy -->
+	<export function="panel_show" type="client" />	<!-- uzywane przez lss-kasyno -->
+
+
+	<export function="eq_getItemByID" type="client" />
+	<export function="eq_takeItem" type="client" />
+	<export function="eq_giveItem" type="client" />
+	<export function="eq_get" type="client" />
+	<export function="eq_item_nav_turnOff" type="client" />
+	<export function="eq_item_nav_clear" type="client" />
 	<export function="eq_getFreeIndex" type="client" />
 	<export function="showAnnouncement" type="client" />
 	<export function="setGPSTarget" type="client" />


### PR DESCRIPTION
Odnośnie https://github.com/lpiob/MTA-XyzzyRP/pull/465 - wczytywany był plik .luac zamiast .lua i korzystało ze starej wersji. 
MTA dodało możliwość niezapisywania plików na dysk poprzez cache="false" i przetrzymywania ich jedynie w pamięci RAM. Pliki ważą na tyle mało, że obecnie nie jest wymagane kodowanie ich do luac.