### PR TITLE
Zablokowanie edycji czyichś budynków

### DIFF
--- a/resources/[XyzzyRP]/lss-budynki/biznesy_zarzadzanie.lua
+++ b/resources/[XyzzyRP]/lss-budynki/biznesy_zarzadzanie.lua
@@ -9,16 +9,24 @@
 addEvent("doSaveBudynekData", true)
 addEventHandler("doSaveBudynekData", resourceRoot, function(plr,budynek)
     if (not budynek or not budynek.id) then 
-		outputChatBox("(( Nie udało się zapisać ustawień budynku. ))", plr)
-		return 
+      outputChatBox("(( Nie udało się zapisać ustawień budynku. ))", plr)
+      return 
     end
-	if (budynek.linkedContainer and budynek.nowyszyfr and string.len(budynek.nowyszyfr)>3 and string.len(budynek.nowyszyfr)<=7 and tonumber(budynek.nowyszyfr)) then
-
-		local query=string.format("UPDATE lss_containers SET szyfr='%s' WHERE id=%d AND typ='sejf' LIMIT 1", exports.DB:esc(budynek.nowyszyfr), budynek.linkedContainer)
-		exports.DB:zapytanie(query)
-		outputChatBox("(( Szyfr w sejfie został zmieniony ))", plr)
-	end
-    -- todo weryfikacja uprawnien
+    local character = getElementData(plr, "character")
+    if not character or not character.id then
+      outputChatBox("(( Nie możesz korzystać z budynków będąc niezalogowanym. ))", plr)
+      return
+    end
+    local currentOwner = exports["DB2"]:pobierzWyniki("SELECT character_id FROM lss_budynki_owners WHERE budynek_id = ? AND character_id = ?", budynek.id, character.id)
+    if not currentOwner or not currentOwner.character_id then
+      outputChatBox("(( Nie możesz edytować tego budynku. ))", plr)
+      return
+    end
+    if (budynek.linkedContainer and budynek.nowyszyfr and string.len(budynek.nowyszyfr)>3 and string.len(budynek.nowyszyfr)<=7 and tonumber(budynek.nowyszyfr)) then
+      local query=string.format("UPDATE lss_containers SET szyfr='%s' WHERE id=%d AND typ='sejf' LIMIT 1", exports.DB:esc(budynek.nowyszyfr), budynek.linkedContainer)
+      exports.DB:zapytanie(query)
+      outputChatBox("(( Szyfr w sejfie został zmieniony ))", plr)
+    end
     local query=string.format("UPDATE lss_budynki SET descr2='%s',entryCost=%d,zamkniety=%d WHERE id=%d LIMIT 1", exports.DB:esc(budynek.descr2_orig), budynek.entryCost, budynek.zamkniety, budynek.id)
     exports.DB:zapytanie(query)
 --    outputDebugString(query)


### PR DESCRIPTION
MTA posiada buga w CEGUI. Gdy przytrzymamy LPM na opcji "Ustawienia" w swoim budynku, nie puszczając go pójdziemy do czyjegoś biznesu i klikniemy PPM, możemy edytować jego budynek mimo braku przycisku "Ustawienia" w tym GUI. Kod ten blokuje możliwość edycji czyjegoś budynku.