### PR TITLE
Fix klonowania przedmiotów - server

### DIFF
--- a/resources/[XyzzyRP]/lss-gui/ekwipunek_s.lua
+++ b/resources/[XyzzyRP]/lss-gui/ekwipunek_s.lua
@@ -18,7 +18,15 @@ function findRotation(x1,y1,x2,y2)
  
 end
 
+addEvent("switchServerItem", true)
+addEventHandler("switchServerItem", resourceRoot, function(last_ctrl_clicked_btn, btnidx)
+	triggerClientEvent(client, "switchClientItem", resourceRoot, last_ctrl_clicked_btn, btnidx)
+end)
 
+addEvent("dropServerItem", true)
+addEventHandler("dropServerItem", resourceRoot, function(btnidx)
+	triggerClientEvent(client, "dropClientItem", resourceRoot, btnidx)
+end)
 
 addEvent("setPedFightingStyler", true)
 addEventHandler("setPedFightingStyler", getRootElement(), function(i)


### PR DESCRIPTION
Możliwe było klonowanie przedmiotów poprzez np. odłączenie internetu i wyrzucenie przedmiotów/zmiany slota na lagu i w międzyczasie wrzucenie ich do bagażnika a następnie ponowne podłączenie internetu. Poprawka blokuje wyrzucanie przedmiotów podczas laga - przejście przez serwer blokuje możliwość wyrzucenia przedmiotu, gdy chwilowo nie ma internetu. Poprawka załatwia większość błędów z klonowaniem. Poprawka przetestowana grze, wszystko działa.