### PR TITLE
fix bugowania kajdanek

### DIFF
--- a/resources/[XyzzyRP]/lss-frakcje/policja_c.lua
+++ b/resources/[XyzzyRP]/lss-frakcje/policja_c.lua
@@ -40,6 +40,9 @@ local function follow()
 --	rx,ry,rz=getElementRotation(localPlayer)
 --	setElementRotation(localPlayer, rx,ry,kat)
 	setPedRotation(localPlayer, kat)
+	if getPedAnimation(localPlayer) then
+		setPedAnimation(localPlayer)
+	end
 	local dist=getDistanceBetweenPoints3D(x,y,z,x2,y2,z2)
 	if (dist<1) then
 		setControlState("forwards", false)


### PR DESCRIPTION
Ta poprawka naprawia błąd związany z tym, że gdy wpisalismy komendę od animacji np. /machasz to nasza postac nie byla przenoszona ponieważ jest sprawdzenie "if (dist>30) then" przez ktore teleportuje takiego gracza dopiero jak bedzie 30 metrów od funkcjonariusza